### PR TITLE
Changed open_rate from Int to Double

### DIFF
--- a/src/main/java/com/ecwid/maleorang/method/v3_0/lists/StatsInfo.kt
+++ b/src/main/java/com/ecwid/maleorang/method/v3_0/lists/StatsInfo.kt
@@ -59,7 +59,7 @@ class StatsInfo : MailchimpObject() {
 
     @JvmField
     @Field
-    var open_rate: Int? = null
+    var open_rate: Double? = null
 
     @JvmField
     @Field

--- a/src/main/java/com/ecwid/maleorang/method/v3_0/lists/StatsInfo.kt
+++ b/src/main/java/com/ecwid/maleorang/method/v3_0/lists/StatsInfo.kt
@@ -47,15 +47,15 @@ class StatsInfo : MailchimpObject() {
 
     @JvmField
     @Field
-    var avg_sub_rate: Int? = null
+    var avg_sub_rate: Double? = null
 
     @JvmField
     @Field
-    var avg_unsub_rate: Int? = null
+    var avg_unsub_rate: Double? = null
 
     @JvmField
     @Field
-    var target_sub_rate: Int? = null
+    var target_sub_rate: Double? = null
 
     @JvmField
     @Field
@@ -63,7 +63,7 @@ class StatsInfo : MailchimpObject() {
 
     @JvmField
     @Field
-    var click_rate: Int? = null
+    var click_rate: Double? = null
 
     @JvmField
     @Field


### PR DESCRIPTION
This variable is causing the following error while being an Int:

java.lang.IllegalArgumentException: com.google.gson.JsonSyntaxException: java.lang.NumberFormatException: Expected an int but was 40.20618556701 at line 1 column 6339 path $.lists[1].stats.open_rate