### PR TITLE
Add ConditionInfo object and example TextMergeConditionInfo for segment conditions

### DIFF
--- a/src/main/java/com/ecwid/maleorang/method/v3_0/campaigns/CampaignInfo.kt
+++ b/src/main/java/com/ecwid/maleorang/method/v3_0/campaigns/CampaignInfo.kt
@@ -107,7 +107,36 @@ class CampaignInfo : MailchimpObject() {
 
             @JvmField
             @Field
-            var conditions: Array<String>? = null
+            var conditions: Array<ConditionInfo>? = null
+
+            open class ConditionInfo : MailchimpObject() {
+
+                @JvmField
+                @Field
+                var condition_type: String? = null
+
+            }
+
+            class TextMergeConditionInfo : ConditionInfo() {
+
+                @JvmField
+                @Field
+                var field: String? = null
+
+                @JvmField
+                @Field
+                var op: String? = null
+
+                @JvmField
+                @Field
+                var value: String? = null
+
+                init {
+                    condition_type = "TextMerge"
+                }
+
+            }
+
         }
     }
 


### PR DESCRIPTION
This PR changes the `conditions` field in `SegmentOptsInfo` from `Array<String>?` to `Array<ConditionInfo>` so more complex segments can be configured when creating campaigns.

I included the `TextMergeConditionInfo` class  because that is the condition that I needed in my project but the base `ConditionInfo` class is open so other sub classes can be easily added.

This change is kind of not backwards compatible because it changes the type of the `conditions` field so existing code that uses that field as an array of strings will not work anymore. Although I don't know why anyone would use the field like that so I don't think it's an issue.