### PR TITLE
 DeletePermanentMemberMethod, document DeleteMemberMethod as non-permanent archival

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/publish.gradle
+++ b/publish.gradle
@@ -3,7 +3,7 @@ apply plugin: 'signing'
 
 group = 'com.ecwid'
 archivesBaseName = "maleorang"
-version = '3.0-0.9.6'
+version = '3.0-0.9.7'
 
 task javadocJar(type: Jar) {
     classifier = 'javadoc'

--- a/src/main/java/com/ecwid/maleorang/method/v3_0/lists/members/DeletePermanentMemberMethod.kt
+++ b/src/main/java/com/ecwid/maleorang/method/v3_0/lists/members/DeletePermanentMemberMethod.kt
@@ -9,10 +9,10 @@ import com.ecwid.maleorang.annotation.PathParam
 import org.apache.commons.codec.digest.DigestUtils
 
 /**
- * [Archive a list member](https://mailchimp.com/developer/api/marketing/list-members/archive-list-member/)
+ * [Permanently delete a list member](https://mailchimp.com/developer/api/marketing/list-members/delete-list-member/)
  */
-@Method(httpMethod = HttpMethod.DELETE, version = APIVersion.v3_0, path = "/lists/{list_id}/members/{subscriber_hash}")
-class DeleteMemberMethod(
+@Method(httpMethod = HttpMethod.POST, version = APIVersion.v3_0, path = "/lists/{list_id}/members/{subscriber_hash}/actions/delete-permanent")
+class DeletePermanentMemberMethod(
         @JvmField
         @PathParam
         val list_id: String,


### PR DESCRIPTION
Hey all, MC changed the API a bit in this area. The endpoint used by DeleteMemberMethod is now an archival concept, which often doesn't work. I added DeletePermanentMemberMethod to use the newer permanent-delete endpoint.

Also note that I had to change the gradle distributionUrl (https is required) and bumped the release version.